### PR TITLE
perf: Create object and context type lists during analysis

### DIFF
--- a/x2-data-explorer/src/main/java/com/github/rcd47/x2data/explorer/file/HistoryFile.java
+++ b/x2-data-explorer/src/main/java/com/github/rcd47/x2data/explorer/file/HistoryFile.java
@@ -2,6 +2,7 @@ package com.github.rcd47.x2data.explorer.file;
 
 import java.util.List;
 
+import com.github.rcd47.x2data.lib.unreal.mappings.UnrealName;
 import com.github.rcd47.x2data.lib.unreal.mappings.base.XComGameStateHistory;
 
 public class HistoryFile {
@@ -10,13 +11,17 @@ public class HistoryFile {
 	private final List<HistoryFrame> frames;
 	private final List<HistorySingletonObject> singletons;
 	private final List<HistoryFileProblem> problems;
+	private final List<UnrealName> contextTypes;
+	private final List<UnrealName> objectTypes;
 	
 	public HistoryFile(XComGameStateHistory history, List<HistoryFrame> frames, List<HistorySingletonObject> singletons,
-			List<HistoryFileProblem> problems) {
+			List<HistoryFileProblem> problems, List<UnrealName> contextTypes, List<UnrealName> objectTypes) {
 		this.history = history;
 		this.frames = frames;
 		this.singletons = singletons;
 		this.problems = problems;
+		this.contextTypes = contextTypes;
+		this.objectTypes = objectTypes;
 	}
 
 	public XComGameStateHistory getHistory() {
@@ -33,6 +38,14 @@ public class HistoryFile {
 
 	public List<HistoryFileProblem> getProblems() {
 		return problems;
+	}
+
+	public List<UnrealName> getContextTypes() {
+		return contextTypes;
+	}
+
+	public List<UnrealName> getObjectTypes() {
+		return objectTypes;
 	}
 	
 }

--- a/x2-data-explorer/src/main/java/com/github/rcd47/x2data/explorer/jfx/ui/history/HistoryFramesTable.java
+++ b/x2-data-explorer/src/main/java/com/github/rcd47/x2data/explorer/jfx/ui/history/HistoryFramesTable.java
@@ -102,7 +102,7 @@ public class HistoryFramesTable {
 		
 		var toolbar = new ToolBar(colSelector);
 		
-		var contextTypes = history.getFrames().stream().map(f -> f.getContext().getType()).distinct().sorted().toList();
+		var contextTypes = history.getContextTypes();
 		
 		var contextTypeSelector = new MultiSelectMenu<>("context types", contextTypes, n -> n.getOriginal(), s -> {
 			filters.setFilter(0, s.size() == contextTypes.size() ? null : f -> s.contains(f.getContext().getType()));

--- a/x2-data-explorer/src/main/java/com/github/rcd47/x2data/explorer/jfx/ui/history/HistoryObjectsTable.java
+++ b/x2-data-explorer/src/main/java/com/github/rcd47/x2data/explorer/jfx/ui/history/HistoryObjectsTable.java
@@ -80,14 +80,7 @@ public class HistoryObjectsTable {
 		
 		var prefs = GeneralPreferences.getEffective();
 		
-		var types = history
-				.getFrames()
-				.stream()
-				.flatMap(f -> f.getObjects().values().stream())
-				.map(o -> o.getType())
-				.distinct()
-				.sorted()
-				.toList();
+		var types = history.getObjectTypes();
 		
 		var colSelector = new MultiSelectMenu<>(
 				"columns",


### PR DESCRIPTION
In my testing, this shaves a few seconds off analysis of large files